### PR TITLE
Speed up first switch to ledgerview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ build*/
 ui_*.h
 moc_*.cpp
 *.moc
+*.a
+*.so*
+*_automoc.cpp
+**/*.cmake
+**/Makefile
+**/CMakeFiles/
+**/*.desktop
+**/*-test
+CMakeCache.txt
+CMakeTmp/

--- a/kmymoney/widgets/register.cpp
+++ b/kmymoney/widgets/register.cpp
@@ -1060,6 +1060,9 @@ void Register::resize()
 
 void Register::resize(int col, bool force)
 {
+  if (m_needResize)
+    m_minimalColumnWidthCache.clear();
+
   if (!m_needResize && !force)
     return;
 
@@ -1243,7 +1246,15 @@ int Register::minimumColumnWidth(int col)
 
 void Register::adjustColumn(int col)
 {
-  setColumnWidth(col, minimumColumnWidth(col));
+  QMap<int, int>::const_iterator it = m_minimalColumnWidthCache.find(col);
+  int width = 0;
+  if (it == m_minimalColumnWidthCache.end()) {
+    width = minimumColumnWidth(col);
+    m_minimalColumnWidthCache[col] = width;
+  } else {
+    width = it.value();
+  }
+  setColumnWidth(col, width);
 }
 
 void Register::clearSelection()

--- a/kmymoney/widgets/register.h
+++ b/kmymoney/widgets/register.h
@@ -652,6 +652,7 @@ private:
   QList<TransactionSortField>  m_sortOrder;
   QRect                        m_lastRepaintRect;
   DetailsColumnType            m_detailsColumnType;
+  QMap<int, int>               m_minimalColumnWidthCache;
 };
 
 } // namespace


### PR DESCRIPTION
This bug was annoying me for a long time. I use kmymoney for several years and I have about 15k entries (about 5k per one account). Every first switch to ledger view takes ~5s. (package from repo, version 4.6) I was pretty sure that I don't have so much data to process so long. After debugging I saw that problem is in Register::resize that every time goes through all 5k entries for each visible columns and calculating minimal width of column by rendering its text. Register::resize is called about 4 times per first switch (3 times with 'force==true' flag, so guard at the beginning of the function doesn't help us).
So this little optimization makes it possible to call Register::resize as much as you want and it won't affect performance if nothing changed in items.