### PR TITLE
Add an option to merge notes with memo when importing GnuCash file

### DIFF
--- a/kmymoney/plugins/gnc/import/kgncimportoptionsdlg.cpp
+++ b/kmymoney/plugins/gnc/import/kgncimportoptionsdlg.cpp
@@ -75,8 +75,9 @@ public:
     ui->checkDecode->setChecked(false);
     ui->comboDecode->setEnabled(false);
 
-    ui->buttonGroup18->setExclusive(false);
-    ui->checkTxNotes->setChecked(false);
+    ui->buttonTxNotesGroup->setId(ui->radioTxNotes1, 0); // use memo
+    ui->buttonTxNotesGroup->setId(ui->radioTxNotes2, 1); // use notes
+    ui->buttonTxNotesGroup->setId(ui->radioTxNotes3, 2); // merge memo with notes
 
     ui->buttonGroup3->setExclusive(false);
     ui->checkDebugGeneral->setChecked(false);
@@ -160,10 +161,10 @@ QTextCodec* KGncImportOptionsDlg::decodeOption()
   }
 }
 
-bool KGncImportOptionsDlg::txNotesOption() const
+int KGncImportOptionsDlg::txNotesOption() const
 {
   Q_D(const KGncImportOptionsDlg);
-  return (d->ui->checkTxNotes->isChecked());
+  return (d->ui->buttonTxNotesGroup->checkedId());
 }
 
 bool KGncImportOptionsDlg::generalDebugOption() const

--- a/kmymoney/plugins/gnc/import/kgncimportoptionsdlg.h
+++ b/kmymoney/plugins/gnc/import/kgncimportoptionsdlg.h
@@ -45,7 +45,7 @@ public:
   bool quoteOption() const;
   bool scheduleOption() const;
   QTextCodec* decodeOption();
-  bool txNotesOption() const;
+  int txNotesOption() const;
   bool generalDebugOption() const;
   bool xmlDebugOption() const;
   bool anonymizeOption() const;

--- a/kmymoney/plugins/gnc/import/kgncimportoptionsdlg.ui
+++ b/kmymoney/plugins/gnc/import/kgncimportoptionsdlg.ui
@@ -171,18 +171,41 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="buttonGroupBox18">
+    <widget class="QGroupBox" name="buttonTxNotesGroupBox">
      <property name="title">
-      <string>Transaction Notes option</string>
+      <string>Notes option for non-split transactions</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QCheckBox" name="checkTxNotes">
+       <widget class="QRadioButton" name="radioTxNotes1">
         <property name="text">
-         <string>Use transaction notes on non-split transactions</string>
+         <string>Use transaction memo</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
         <attribute name="buttonGroup">
-         <string notr="true">buttonGroup18</string>
+         <string notr="true">buttonTxNotesGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioTxNotes2">
+        <property name="text">
+         <string>Use transaction notes</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonTxNotesGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioTxNotes3">
+        <property name="text">
+         <string>Merge memo and notes</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonTxNotesGroup</string>
         </attribute>
        </widget>
       </item>
@@ -304,11 +327,12 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup18"/>
-  <buttongroup name="buttonGroup2"/>
   <buttongroup name="buttonGroup3"/>
   <buttongroup name="buttonGroup4"/>
   <buttongroup name="buttonGroup5"/>
+  <buttongroup name="buttonGroup2"/>
+  <buttongroup name="buttonGroup18"/>
   <buttongroup name="buttonInvestGroup"/>
+  <buttongroup name="buttonTxNotesGroup"/>
  </buttongroups>
 </ui>

--- a/kmymoney/plugins/gnc/import/mymoneygncreader.h
+++ b/kmymoney/plugins/gnc/import/mymoneygncreader.h
@@ -952,9 +952,10 @@ protected:
     Under some usage conditions, non-split GnuCash transactions may contain residual, usually incorrect, memo
     data which is not normally visible to the user. When imported into KMyMoney however, due to display
     differences, this data can become visible. Often, these transactions will have a Notes field describing
-    the real purpose of the transaction. If this option is selected, these notes, if present, will be used to
-    override the extraneous memo data."  */
-  bool m_useTxNotes;
+    the real purpose of the transaction, so you can choose to use it instead. It may also be that - depending
+    on the source the transactions were imported from - any of these fields could have been used to store useful
+    information and you don't want to choose just one. In this case, you have an option to merge them together."  */
+  int m_useTxNotes;
   // set gnucash counts (not always accurate!)
   void setGncCommodityCount(int i) {
     m_gncCommodityCount = i;


### PR DESCRIPTION
I have used GnuCash for 8 years before deciding to move on to kmymoney, but my non-split transactions use both the Memo and Notes fields, depending on the source they were imported from. Instead of having to choose either of them and loosing some potentially meaningful information, I added an option to the importer that uses both of the fields and merges them together if both are present. 

Tested and works fine with my dataset. 