### PR TITLE
Fix crash caused by using Settings->Configure Toolbars

### DIFF
--- a/kmymoney/kmymoney.cpp
+++ b/kmymoney/kmymoney.cpp
@@ -1130,8 +1130,10 @@ public:
             pActions[action]->setEnabled(m_storageInfo.isOpened);
 
         // make sure all shared actions of the New button have the right state
-        for (const auto action : m_sharedActionButtons[Action::FileNew].button->actions()) {
-            action->setEnabled(m_storageInfo.isOpened);
+        if (m_sharedActionButtons[Action::FileNew].button) {
+            for (const auto action : m_sharedActionButtons[Action::FileNew].button->actions()) {
+                action->setEnabled(m_storageInfo.isOpened);
+            }
         }
         // except the New File/Book which is always enabled
         pActions[Action::FileNew]->setEnabled(true);


### PR DESCRIPTION
This code assumed that the Action::FileNew button would be present, but when the button was removed a null-pointer dereference occurred. This fix is incomplete, because there appear to be additional unsafe references to this (and possibly other) buttons.

I've recently started using KMyMoney, and I have a sizable list of bugs some of which I'd like to try to just fix.   This particular bug required some debugging just so I could progress to doing development on other bugs. ;-)  My apologies for the incomplete nature of this fix, but I'm not familiar enough with the code to do a review of the other places affected.  I know that switching to the Institutions view also caused a crash because of the customized toolbar.  I was able to work around this defect by restoring the toolbar configuration to the default setting once KMyMoney would start successfully.